### PR TITLE
fix: fix bug access tokens create should set the authorization header to null - INTOP-93

### DIFF
--- a/src/resources/access-tokens.ts
+++ b/src/resources/access-tokens.ts
@@ -27,7 +27,15 @@ export class AccessTokens extends APIResource {
       client_id: clientID,
       client_secret: clientSecret,
     };
-    return this._client.post('/auth/token', { body: bodyWithReplacements, ...options });
+    const headersWithReplacements = {
+      ...options?.headers,
+      authorization: null,
+    };
+    return this._client.post('/auth/token', {
+      body: bodyWithReplacements,
+      ...options,
+      headers: headersWithReplacements
+    });
   }
 }
 

--- a/src/resources/access-tokens.ts
+++ b/src/resources/access-tokens.ts
@@ -34,7 +34,7 @@ export class AccessTokens extends APIResource {
     return this._client.post('/auth/token', {
       body: bodyWithReplacements,
       ...options,
-      headers: headersWithReplacements
+      headers: headersWithReplacements,
     });
   }
 }


### PR DESCRIPTION
Fix bug with `accessTokens.create` call.

The authorization header should be set to null on this `POST /auth/token`

Customer can't use the SDK to create the access token using the `accessTokens.create` interface, only the older `getAccessToken` interface.

We can see here that we do it for the `getAccessToken` but not for the newer method.

https://github.com/Finch-API/finch-api-node/blob/main/src/index.ts#L180-L190

* [INTOP-93](https://linear.app/finch/issue/INTOP-93)