### PR TITLE
Revert "chore(docs): minor update to formatting of API link in README…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This library provides convenient access to the Finch REST API from server-side TypeScript or JavaScript.
 
-The REST API documentation can be found on [developer.tryfinch.com](https://developer.tryfinch.com/). The full API of this library can be found in [api.md](api.md).
+The REST API documentation can be found [in the Finch Documentation Center](https://developer.tryfinch.com/). The full API of this library can be found in [api.md](api.md).
 
 ## Installation
 


### PR DESCRIPTION
… (#403)"

This reverts commit b82f8df45b3b3b7b441827e42fad44d1c84fbbd4.

This preserves the custom wording this repo is using for linking to the API Documentation.